### PR TITLE
Removed Allowed Failure on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ matrix:
     - os: osx
       osx_image: xcode7.3
 
-  allow_failures:
-    - os: osx
-      osx_image: xcode7.3
-
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update        ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gradle; fi


### PR DESCRIPTION
We fixed the OSX build recently, so it's not allowed to fail anymore.