### PR TITLE
Move to SceneryDefaultApplication

### DIFF
--- a/src/main/kotlin/scenery/SceneryDefaultApplication.kt
+++ b/src/main/kotlin/scenery/SceneryDefaultApplication.kt
@@ -15,7 +15,9 @@ import scenery.repl.REPL
  * @author Ulrik Günther <hello@ulrik.is>
  */
 
-open class SceneryDefaultApplication(var applicationName: String) {
+open class SceneryDefaultApplication(var applicationName: String,
+                                     var windowWidth: Int = 1024,
+                                     var windowHeight: Int = 1024) {
     protected val scene: Scene = Scene()
     protected val repl: REPL = REPL()
     protected var frameNum = 0
@@ -80,8 +82,8 @@ open class SceneryDefaultApplication(var applicationName: String) {
         }
 
         val glWindow = ClearGLWindow("",
-                1024,
-                1024,
+                windowWidth,
+                windowHeight,
                 lClearGLWindowEventListener)
         glWindow.isVisible = true
         glWindow.setFPS(60)

--- a/src/test/kotlin/scenery/tests/examples/BoxedProteinExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/BoxedProteinExample.kt
@@ -1,245 +1,159 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import com.jogamp.opengl.GLException
 import org.junit.Test
-import org.scijava.Context
-import org.scijava.`object`.ObjectService
-import org.scijava.app.SciJavaApp
-import org.scijava.plugin.Plugin
-import org.scijava.ui.swing.script.AutoImporter
-import org.scijava.ui.swing.script.InterpreterWindow
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.rendermodules.opengl.DeferredLightingRenderer
 import java.io.IOException
-import java.util.*
 import kotlin.concurrent.thread
 
 /**
  * Created by ulrik on 20/01/16.
  */
-class BoxedProteinExample {
+class BoxedProteinExample : SceneryDefaultApplication("BoxedProteinExample") {
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        try {
+            deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
+                    glWindow!!.width,
+                    glWindow!!.height)
+            hub.add(SceneryElement.RENDERER, deferredRenderer!!)
 
+            val cam: Camera = DetachedHeadCamera()
 
-    private val scene: Scene = Scene()
-    private var interpreter: InterpreterWindow? = null
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
-    private var hub: Hub = Hub()
+            fun rangeRandomizer(min: Float, max: Float): Float = min + (Math.random().toFloat() * ((max - min) + 1.0f))
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+            var boxes = (0..2).map {
+                Box(GLVector(0.5f, 0.5f, 0.5f))
+            }
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+            var lights = (0..2).map {
+                PointLight()
+            }
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                try {
-                    deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
-                            mClearGLWindow!!.width,
-                            mClearGLWindow!!.height)
-                    hub.add(SceneryElement.RENDERER, deferredRenderer!!)
+            boxes.mapIndexed { i, box ->
+                box.material = Material()
+                box.addChild(lights[i])
+                scene.addChild(box)
+            }
 
-                    val cam: Camera = DetachedHeadCamera()
+            lights.map {
+                it.position = GLVector(rangeRandomizer(-600.0f, 600.0f),
+                        rangeRandomizer(-600.0f, 600.0f),
+                        rangeRandomizer(-600.0f, 600.0f))
+                it.emissionColor = GLVector(rangeRandomizer(0.0f, 1.0f),
+                        rangeRandomizer(0.0f, 1.0f),
+                        rangeRandomizer(0.0f, 1.0f))
+                it.parent?.material?.diffuse = it.emissionColor
+                it.intensity = rangeRandomizer(0.01f, 500f)
+                it.linear = 0.01f;
+                it.quadratic = 0.01f;
 
-                    fun rangeRandomizer(min: Float, max: Float): Float = min + (Math.random().toFloat() * ((max - min) + 1.0f))
+                scene.addChild(it)
+            }
 
-                    var boxes = (0..2).map {
-                        Box(GLVector(0.5f, 0.5f, 0.5f))
-                    }
+            val hullbox = Box(GLVector(100.0f, 100.0f, 100.0f))
+            hullbox.position = GLVector(0.0f, 0.0f, 0.0f)
+            val hullboxM = Material()
+            hullboxM.ambient = GLVector(0.6f, 0.6f, 0.6f)
+            hullboxM.diffuse = GLVector(0.4f, 0.4f, 0.4f)
+            hullboxM.specular = GLVector(0.0f, 0.0f, 0.0f)
+            hullboxM.doubleSided = true
+            hullbox.material = hullboxM
 
-                    var lights = (0..2).map {
-                        PointLight()
-                    }
+            scene.addChild(hullbox)
 
-                    boxes.mapIndexed { i, box ->
-                        box.material = Material()
-                        box.addChild(lights[i])
-                        scene.addChild(box)
-                    }
+            val mesh = Mesh()
+            val meshM = Material()
+            meshM.ambient = GLVector(0.8f, 0.8f, 0.8f)
+            meshM.diffuse = GLVector(0.5f, 0.5f, 0.5f)
+            meshM.specular = GLVector(0.1f, 0f, 0f)
 
-                    lights.map {
-                        it.position = GLVector(rangeRandomizer(-600.0f, 600.0f),
-                                rangeRandomizer(-600.0f, 600.0f),
-                                rangeRandomizer(-600.0f, 600.0f))
-                        it.emissionColor = GLVector(rangeRandomizer(0.0f, 1.0f),
-                                rangeRandomizer(0.0f, 1.0f),
-                                rangeRandomizer(0.0f, 1.0f))
-                        it.parent?.material?.diffuse = it.emissionColor
-                        it.intensity = rangeRandomizer(0.01f, 500f)
-                        it.linear = 0.01f;
-                        it.quadratic = 0.01f;
-
-                        scene.addChild(it)
-                    }
-
-                    val hullbox = Box(GLVector(100.0f, 100.0f, 100.0f))
-                    hullbox.position = GLVector(0.0f, 0.0f, 0.0f)
-                    val hullboxM = Material()
-                    hullboxM.ambient = GLVector(0.6f, 0.6f, 0.6f)
-                    hullboxM.diffuse = GLVector(0.4f, 0.4f, 0.4f)
-                    hullboxM.specular = GLVector(0.0f, 0.0f, 0.0f)
-                    hullboxM.doubleSided = true
-                    hullbox.material = hullboxM
-
-                    scene.addChild(hullbox)
-
-                    val mesh = Mesh()
-                    val meshM = Material()
-                    meshM.ambient = GLVector(0.8f, 0.8f, 0.8f)
-                    meshM.diffuse = GLVector(0.5f, 0.5f, 0.5f)
-                    meshM.specular = GLVector(0.1f, 0f, 0f)
-
-                    mesh.readFromOBJ(System.getenv("SCENERY_DEMO_FILES") + "/ORC6.obj")
+            mesh.readFromOBJ(System.getenv("SCENERY_DEMO_FILES") + "/ORC6.obj")
 //                    mesh.position = GLVector(155.5f, 150.5f, 55.0f)
-                    mesh.position = GLVector(0.1f, 0.1f, 0.1f)
-                    mesh.material = meshM
-                    mesh.scale = GLVector(1.0f, 1.0f, 1.0f)
-                    mesh.updateWorld(true, true)
-                    mesh.name = "ORC6"
-                    mesh.children.forEach { it.material = meshM }
+            mesh.position = GLVector(0.1f, 0.1f, 0.1f)
+            mesh.material = meshM
+            mesh.scale = GLVector(1.0f, 1.0f, 1.0f)
+            mesh.updateWorld(true, true)
+            mesh.name = "ORC6"
+            mesh.children.forEach { it.material = meshM }
 
-                    scene.addChild(mesh)
+            scene.addChild(mesh)
 
-                    cam.position = GLVector(0.0f, 0.0f, 0.0f)
-                    cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+            cam.position = GLVector(0.0f, 0.0f, 0.0f)
+            cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
 
-                    cam.projection = GLMatrix().setPerspectiveProjectionMatrix(
-                            50.0f / 180.0f * Math.PI.toFloat(),
-                            pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f).invert()
-                    cam.active = true
+            cam.projection = GLMatrix().setPerspectiveProjectionMatrix(
+                    50.0f / 180.0f * Math.PI.toFloat(),
+                    pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f).invert()
+            cam.active = true
 
-                    scene.addChild(cam)
+            scene.addChild(cam)
 
-                    var ticks: Int = 0
+            var ticks: Int = 0
 
-                    System.out.println(scene.children)
+            System.out.println(scene.children)
 
-                    thread {
-                        var reverse = false
-                        val step = 0.02f
+            thread {
+                var reverse = false
+                val step = 0.02f
 
-                        while (true) {
-                            boxes.mapIndexed {
-                                i, box ->
-                                //                                light.position.set(i % 3, step*10 * ticks)
-                                val phi = Math.PI * 2.0f * ticks/500.0f
+                while (true) {
+                    boxes.mapIndexed {
+                        i, box ->
+                        //                                light.position.set(i % 3, step*10 * ticks)
+                        val phi = Math.PI * 2.0f * ticks / 500.0f
 
-                                box.position = GLVector(
-                                        Math.exp(i.toDouble()).toFloat() * 20 * Math.sin(phi).toFloat() + Math.exp(i.toDouble()).toFloat(),
-                                        step*ticks,
-                                        Math.exp(i.toDouble()).toFloat() * 20 * Math.cos(phi).toFloat() + Math.exp(i.toDouble()).toFloat())
+                        box.position = GLVector(
+                                Math.exp(i.toDouble()).toFloat() * 20 * Math.sin(phi).toFloat() + Math.exp(i.toDouble()).toFloat(),
+                                step * ticks,
+                                Math.exp(i.toDouble()).toFloat() * 20 * Math.cos(phi).toFloat() + Math.exp(i.toDouble()).toFloat())
 
-                                box.children[0].position = box.position
+                        box.children[0].position = box.position
 
-                            }
+                    }
 
-                            if (ticks >= 5000 && reverse == false) {
-                                reverse = true
-                            }
-                            if (ticks <= 0 && reverse == true) {
-                                reverse = false
-                            }
+                    if (ticks >= 5000 && reverse == false) {
+                        reverse = true
+                    }
+                    if (ticks <= 0 && reverse == true) {
+                        reverse = false
+                    }
 
-                            if (reverse) {
-                                ticks--
-                            } else {
-                                ticks++
-                            }
+                    if (reverse) {
+                        ticks--
+                    } else {
+                        ticks++
+                    }
 
 //                            mesh.children[0].rotation.rotateByAngleX(0.001f)
 //                            mesh.children[0].updateWorld(true, true)
 
-                            Thread.sleep(10)
-                        }
-                    }
-
-                    val context: Context = Context()
-                    context.getService(ObjectService::class.java).addObject(scene)
-                    context.getService(ObjectService::class.java).addObject(deferredRenderer)
-
-                    interpreter = InterpreterWindow(context)
-                    interpreter?.isVisible = true
-
-                    deferredRenderer?.initializeScene(scene)
-                } catch (e: GLException) {
-                    e.printStackTrace()
-                } catch (e: IOException) {
-                    e.printStackTrace()
+                    Thread.sleep(10)
                 }
-
             }
 
-            override fun reshape(pDrawable: GLAutoDrawable,
-                                 pX: Int,
-                                 pY: Int,
-                                 pWidth: Int,
-                                 pHeight: Int) {
-                var pHeight = pHeight
+            repl.addAccessibleObject(scene)
+            repl.addAccessibleObject(deferredRenderer!!)
 
-                if (pHeight == 0)
-                    pHeight = 1
+            repl.start();
+            repl.showConsoleWindow()
 
-                super.reshape(pDrawable, pX, pY, pWidth, pHeight)
-                deferredRenderer?.reshape(pWidth, pHeight)
-                val ratio = 1.0f * pWidth / pHeight
-            }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
-        }
-
-        val lClearGLWindow = ClearGLWindow("",
-                1280,
-                720,
-                lClearGLWindowEventListener)
-
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
-
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
-
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
-        }
-    }
-
-    @Test fun ScenegraphSimpleDemo() {
-
-    }
-
-    @Plugin(type = AutoImporter::class)
-    companion object ScenePlugin : AutoImporter {
-        override fun getDefaultImports(): MutableMap<String, MutableList<String>>? {
-            val name = SciJavaApp::class.simpleName!!
-            val dot = name.lastIndexOf('.');
-            val base = name.substring(dot + 1);
-            System.out.println("Imported " + base + "; Try:\n\n\tprint(" + base + ".NAME);");
-
-            val map: MutableMap<String, MutableList<String>> = HashMap<String, MutableList<String>>();
-            map.put(name.substring(0, dot), Arrays.asList(base));
-            return map;
+            deferredRenderer?.initializeScene(scene)
+        } catch (e: GLException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
         }
 
     }
+
+    @Test override fun main() {
+        super.main()
+    }
+
 }
 

--- a/src/test/kotlin/scenery/tests/examples/CubeExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/CubeExample.kt
@@ -1,10 +1,10 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import org.junit.Test
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.rendermodules.opengl.DeferredLightingRenderer
 import kotlin.concurrent.thread
 
@@ -13,97 +13,59 @@ import kotlin.concurrent.thread
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-class CubeExample {
-    private val scene: Scene = Scene()
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
+class CubeExample : SceneryDefaultApplication("CubeExample") {
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, glWindow!!.width, glWindow!!.height)
+        hub.add(SceneryElement.RENDERER, deferredRenderer!!)
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+        var box = Box(GLVector(1.0f, 1.0f, 1.0f))
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+        var boxmaterial = Material()
+        boxmaterial.ambient = GLVector(1.0f, 0.0f, 0.0f)
+        boxmaterial.diffuse = GLVector(0.0f, 1.0f, 0.0f)
+        boxmaterial.specular = GLVector(1.0f, 1.0f, 1.0f)
+        box.position = GLVector(0.0f, 0.0f, 0.0f)
+        box.material = boxmaterial
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, mClearGLWindow!!.width, mClearGLWindow!!.height)
+        scene.addChild(box)
 
-                var box = Box(GLVector(1.0f, 1.0f, 1.0f))
-
-                var boxmaterial = Material()
-                boxmaterial.ambient = GLVector(1.0f, 0.0f, 0.0f)
-                boxmaterial.diffuse = GLVector(0.0f, 1.0f, 0.0f)
-                boxmaterial.specular = GLVector(1.0f, 1.0f, 1.0f)
-                box.position = GLVector(0.0f, 0.0f, 0.0f)
-                box.material = boxmaterial
-
-                scene.addChild(box)
-
-                var lights = (0..2).map {
-                    PointLight()
-                }
-
-                lights.mapIndexed { i, light ->
-                    light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
-                    light.emissionColor = GLVector(0.0f, 0.1f, 0.8f)
-                    light.intensity = 0.8f;
-                    scene.addChild(light)
-                }
-
-                val cam: Camera = DetachedHeadCamera()
-                cam.position = GLVector(0.0f, 0.0f, -5.0f)
-                cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
-                cam.projection = GLMatrix()
-                        .setPerspectiveProjectionMatrix(
-                                70.0f / 180.0f * Math.PI.toFloat(),
-                                pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f)
-                        .invert()
-                cam.active = true
-
-                scene.addChild(cam)
-
-                thread {
-                    while (true) {
-                        box.rotation.rotateByAngleY(0.01f)
-                        box.needsUpdate = true
-
-                        Thread.sleep(20)
-                    }
-                }
-                deferredRenderer?.initializeScene(scene)
-            }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
+        var lights = (0..2).map {
+            PointLight()
         }
 
-        val lClearGLWindow = ClearGLWindow("",
-                1024,
-                1024,
-                lClearGLWindowEventListener)
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
-
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
-
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
+        lights.mapIndexed { i, light ->
+            light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
+            light.emissionColor = GLVector(0.0f, 0.1f, 0.8f)
+            light.intensity = 0.8f;
+            scene.addChild(light)
         }
+
+        val cam: Camera = DetachedHeadCamera()
+        cam.position = GLVector(0.0f, 0.0f, -5.0f)
+        cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+        cam.projection = GLMatrix()
+                .setPerspectiveProjectionMatrix(
+                        70.0f / 180.0f * Math.PI.toFloat(),
+                        pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f)
+                .invert()
+        cam.active = true
+
+        scene.addChild(cam)
+
+        thread {
+            while (true) {
+                box.rotation.rotateByAngleY(0.01f)
+                box.needsUpdate = true
+
+                Thread.sleep(20)
+            }
+        }
+        deferredRenderer?.initializeScene(scene)
+    }
+
+
+    @Test override fun main() {
+        super.main()
     }
 }

--- a/src/test/kotlin/scenery/tests/examples/LineExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/LineExample.kt
@@ -1,10 +1,10 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import org.junit.Test
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.rendermodules.opengl.DeferredLightingRenderer
 
 /**
@@ -12,94 +12,56 @@ import scenery.rendermodules.opengl.DeferredLightingRenderer
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-class LineExample {
-    private val scene: Scene = Scene()
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
+class LineExample : SceneryDefaultApplication("LineExample") {
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, glWindow!!.width, glWindow!!.height)
+        hub.add(SceneryElement.RENDERER, deferredRenderer!!)
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+        var linematerial = Material()
+        linematerial.ambient = GLVector(1.0f, 0.0f, 0.0f)
+        linematerial.diffuse = GLVector(0.0f, 1.0f, 0.0f)
+        linematerial.specular = GLVector(1.0f, 1.0f, 1.0f)
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+        var line = Line()
+        line.addPoint(GLVector(-1.0f, -1.0f, -1.0f))
+        line.addPoint(GLVector(0.0f, 1.0f, 0.0f))
+        line.addPoint(GLVector(2.0f, 0.0f, 2.0f))
+        line.addPoint(GLVector(10.0f, 5.0f, 10.0f))
+        line.material = linematerial
+        line.preDraw()
+        line.position = GLVector(0.0f, 0.0f, 1.1f)
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, mClearGLWindow!!.width, mClearGLWindow!!.height)
+        scene.addChild(line)
 
-                var linematerial = Material()
-                linematerial.ambient = GLVector(1.0f, 0.0f, 0.0f)
-                linematerial.diffuse = GLVector(0.0f, 1.0f, 0.0f)
-                linematerial.specular = GLVector(1.0f, 1.0f, 1.0f)
-
-                var line = Line()
-                line.addPoint(GLVector(-1.0f, -1.0f, -1.0f))
-                line.addPoint(GLVector(0.0f, 1.0f, 0.0f))
-                line.addPoint(GLVector(2.0f, 0.0f, 2.0f))
-                line.addPoint(GLVector(10.0f, 5.0f, 10.0f))
-                line.material = linematerial
-                line.preDraw()
-                line.position = GLVector(0.0f, 0.0f, 1.1f)
-
-                scene.addChild(line)
-
-                var lights = (0..2).map {
-                    PointLight()
-                }
-
-                lights.mapIndexed { i, light ->
-                    light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
-                    light.emissionColor = GLVector(1.0f, 0.0f, 1.0f)
-                    light.intensity = 0.8f*(i+1);
-                    scene.addChild(light)
-                }
-
-                val cam: Camera = DetachedHeadCamera()
-                cam.position = GLVector(0.0f, 0.0f, -5.0f)
-                cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
-                cam.projection = GLMatrix()
-                        .setPerspectiveProjectionMatrix(
-                                70.0f / 180.0f * Math.PI.toFloat(),
-                                pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f)
-                        .invert()
-                cam.active = true
-
-                scene.addChild(cam)
-
-                deferredRenderer?.initializeScene(scene)
-            }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
+        var lights = (0..2).map {
+            PointLight()
         }
 
-        val lClearGLWindow = ClearGLWindow("",
-                1024,
-                1024,
-                lClearGLWindowEventListener)
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
-
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
-
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
+        lights.mapIndexed { i, light ->
+            light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
+            light.emissionColor = GLVector(1.0f, 0.0f, 1.0f)
+            light.intensity = 0.8f * (i + 1);
+            scene.addChild(light)
         }
+
+        val cam: Camera = DetachedHeadCamera()
+        cam.position = GLVector(0.0f, 0.0f, -5.0f)
+        cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+        cam.projection = GLMatrix()
+                .setPerspectiveProjectionMatrix(
+                        70.0f / 180.0f * Math.PI.toFloat(),
+                        pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f)
+                .invert()
+        cam.active = true
+
+        scene.addChild(cam)
+
+        deferredRenderer?.initializeScene(scene)
+    }
+
+
+    @Test override fun main() {
+        super.main()
     }
 }

--- a/src/test/kotlin/scenery/tests/examples/MultiBoxExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/MultiBoxExample.kt
@@ -1,11 +1,11 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import com.jogamp.opengl.GLException
 import org.junit.Test
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.rendermodules.opengl.DeferredLightingRenderer
 import java.io.IOException
 import kotlin.concurrent.thread
@@ -13,183 +13,125 @@ import kotlin.concurrent.thread
 /**
  * Created by ulrik on 20/01/16.
  */
-class MultiBoxExample {
+class MultiBoxExample : SceneryDefaultApplication("MultiBoxExample") {
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        try {
+            deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
+                    glWindow!!.width,
+                    glWindow!!.height)
+            hub.add(SceneryElement.RENDERER, deferredRenderer!!)
 
+            val cam: Camera = DetachedHeadCamera()
 
-    private val scene: Scene = Scene()
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
+            fun rangeRandomizer(min: Float, max: Float): Float = min + (Math.random().toFloat() * ((max - min) + 1.0f))
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+            val WIDTH = 10.0
+            val HEIGHT = 10.0
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+            val m = Mesh()
+            val boxes = (0..1000).map {
+                Box(GLVector(0.2f, 0.2f, 0.2f))
+            }
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                try {
-                    deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
-                            mClearGLWindow!!.width,
-                            mClearGLWindow!!.height)
+            boxes.mapIndexed {
+                s, box ->
 
-                    val cam: Camera = DetachedHeadCamera()
+                val k: Double = s % WIDTH;
+                val j: Double = (s / WIDTH) % HEIGHT;
+                val i: Double = s / (WIDTH * HEIGHT);
 
-                    fun rangeRandomizer(min: Float, max: Float): Float = min + (Math.random().toFloat() * ((max - min) + 1.0f))
+                box.position = GLVector(Math.floor(i).toFloat() * 3.0f, Math.floor(j).toFloat() * 3.0f, Math.floor(k).toFloat() * 3.0f)
 
-                    val WIDTH = 10.0
-                    val HEIGHT = 10.0
+                m.addChild(box)
+            }
 
-                    val m = Mesh()
-                    val boxes = (0..1000).map {
-                        Box(GLVector(0.2f, 0.2f, 0.2f))
+            scene.addChild(m)
+
+            var lights = (0..10).map {
+                PointLight()
+            }
+
+            boxes.mapIndexed { i, box ->
+                box.material = Material()
+            }
+
+            lights.map {
+                it.position = GLVector(rangeRandomizer(-600.0f, 600.0f),
+                        rangeRandomizer(-600.0f, 600.0f),
+                        rangeRandomizer(-600.0f, 600.0f))
+                it.emissionColor = GLVector(1.0f, 1.0f, 1.0f)
+                it.intensity = rangeRandomizer(0.01f, 1000f)
+                it.linear = 0.1f;
+                it.quadratic = 0.1f;
+
+                scene.addChild(it)
+            }
+
+            val hullbox = Box(GLVector(100.0f, 100.0f, 100.0f))
+            hullbox.position = GLVector(0.0f, 0.0f, 0.0f)
+            val hullboxM = Material()
+            hullboxM.ambient = GLVector(0.6f, 0.6f, 0.6f)
+            hullboxM.diffuse = GLVector(0.4f, 0.4f, 0.4f)
+            hullboxM.specular = GLVector(0.0f, 0.0f, 0.0f)
+            hullboxM.doubleSided = true
+            hullbox.material = hullboxM
+
+            scene.addChild(hullbox)
+
+            val mesh = Mesh()
+            val meshM = Material()
+            meshM.ambient = GLVector(0.5f, 0.5f, 0.5f)
+            meshM.diffuse = GLVector(0.5f, 0.5f, 0.5f)
+            meshM.specular = GLVector(0.1f, 0.1f, 0.1f)
+
+            cam.position = GLVector(0.0f, 0.0f, 0.0f)
+            cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+
+            cam.projection = GLMatrix().setPerspectiveProjectionMatrix(
+                    70.0f / 180.0f * Math.PI.toFloat(),
+                    pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f).invert()
+            cam.active = true
+
+            scene.addChild(cam)
+
+            var ticks: Int = 0
+
+            thread {
+                val step = 0.02f
+
+                while (true) {
+                    lights.mapIndexed {
+                        i, light ->
+                        val phi = Math.PI * 2.0f * ticks / 500.0f
+
+                        light.position = GLVector(
+                                Math.exp(i.toDouble()).toFloat() * 10 * Math.sin(phi).toFloat() + Math.exp(i.toDouble()).toFloat(),
+                                step * ticks,
+                                Math.exp(i.toDouble()).toFloat() * 10 * Math.cos(phi).toFloat() + Math.exp(i.toDouble()).toFloat())
+
                     }
 
-                    boxes.mapIndexed {
-                        s, box ->
+                    ticks++
 
-                        val k: Double = s % WIDTH;
-                        val j: Double = (s / WIDTH) % HEIGHT;
-                        val i: Double = s / (WIDTH * HEIGHT);
+                    m.rotation.rotateByEuler(0.001f, 0.001f, 0.0f)
+                    m.needsUpdate = true
 
-                        box.position = GLVector(Math.floor(i).toFloat()*3.0f, Math.floor(j).toFloat()*3.0f, Math.floor(k).toFloat()*3.0f)
-
-                        m.addChild(box)
-                    }
-
-                    scene.addChild(m)
-
-                    var lights = (0..10).map {
-                        PointLight()
-                    }
-
-                    boxes.mapIndexed { i, box ->
-                        box.material = Material()
-                    }
-
-                    lights.map {
-                        it.position = GLVector(rangeRandomizer(-600.0f, 600.0f),
-                                rangeRandomizer(-600.0f, 600.0f),
-                                rangeRandomizer(-600.0f, 600.0f))
-                        it.emissionColor = GLVector(1.0f, 1.0f, 1.0f)
-                        it.intensity = rangeRandomizer(0.01f, 1000f)
-                        it.linear = 0.1f;
-                        it.quadratic = 0.1f;
-
-                        scene.addChild(it)
-                    }
-
-                    val hullbox = Box(GLVector(100.0f, 100.0f, 100.0f))
-                    hullbox.position = GLVector(0.0f, 0.0f, 0.0f)
-                    val hullboxM = Material()
-                    hullboxM.ambient = GLVector(0.6f, 0.6f, 0.6f)
-                    hullboxM.diffuse = GLVector(0.4f, 0.4f, 0.4f)
-                    hullboxM.specular = GLVector(0.0f, 0.0f, 0.0f)
-                    hullboxM.doubleSided = true
-                    hullbox.material = hullboxM
-
-                    scene.addChild(hullbox)
-
-                    val mesh = Mesh()
-                    val meshM = Material()
-                    meshM.ambient = GLVector(0.5f, 0.5f, 0.5f)
-                    meshM.diffuse = GLVector(0.5f, 0.5f, 0.5f)
-                    meshM.specular = GLVector(0.1f, 0.1f, 0.1f)
-
-                    cam.position = GLVector(0.0f, 0.0f, 0.0f)
-                    cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
-
-                    cam.projection = GLMatrix().setPerspectiveProjectionMatrix(
-                            70.0f / 180.0f * Math.PI.toFloat(),
-                            pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f).invert()
-                    cam.active = true
-
-                    scene.addChild(cam)
-
-                    var ticks: Int = 0
-
-                    thread {
-                        val step = 0.02f
-
-                        while (true) {
-                            lights.mapIndexed {
-                                i, light ->
-                                val phi = Math.PI * 2.0f * ticks/500.0f
-
-                                light.position = GLVector(
-                                        Math.exp(i.toDouble()).toFloat()*10*Math.sin(phi).toFloat()+Math.exp(i.toDouble()).toFloat(),
-                                        step*ticks,
-                                        Math.exp(i.toDouble()).toFloat()*10*Math.cos(phi).toFloat()+Math.exp(i.toDouble()).toFloat())
-
-                            }
-
-                            ticks++
-
-                            m.rotation.rotateByEuler(0.001f, 0.001f, 0.0f)
-                            m.needsUpdate = true
-
-                            Thread.sleep(10)
-                        }
-                    }
-
-                    deferredRenderer?.initializeScene(scene)
-                } catch (e: GLException) {
-                    e.printStackTrace()
-                } catch (e: IOException) {
-                    e.printStackTrace()
+                    Thread.sleep(10)
                 }
-
             }
 
-            override fun reshape(pDrawable: GLAutoDrawable,
-                                 pX: Int,
-                                 pY: Int,
-                                 pWidth: Int,
-                                 pHeight: Int) {
-                var pHeight = pHeight
-                super.reshape(pDrawable, pX, pY, pWidth, pHeight)
-
-                if (pHeight == 0)
-                    pHeight = 1
-                val ratio = 1.0f * pWidth / pHeight
-            }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
+            deferredRenderer?.initializeScene(scene)
+        } catch (e: GLException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
         }
 
-        val lClearGLWindow = ClearGLWindow("",
-                1280,
-                720,
-                lClearGLWindowEventListener)
-
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
-
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
-
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
-        }
     }
 
-    @Test fun ScenegraphSimpleDemo() {
-
+    @Test override fun main() {
+        super.main()
     }
+
 }

--- a/src/test/kotlin/scenery/tests/examples/MultiBoxInstancedExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/MultiBoxInstancedExample.kt
@@ -1,11 +1,11 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import com.jogamp.opengl.GLException
 import org.junit.Test
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.rendermodules.opengl.DeferredLightingRenderer
 import scenery.rendermodules.opengl.OpenGLShaderPreference
 import java.io.IOException
@@ -15,197 +15,138 @@ import kotlin.concurrent.thread
 /**
  * Created by ulrik on 20/01/16.
  */
-class MultiBoxInstancedExample {
+class MultiBoxInstancedExample : SceneryDefaultApplication("MultiBoxInstancedExample") {
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        try {
+            deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
+                    glWindow!!.width,
+                    glWindow!!.height)
 
+            val cam: Camera = DetachedHeadCamera()
 
-    private val scene: Scene = Scene()
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
+            fun rangeRandomizer(min: Float, max: Float): Float = min + (Math.random().toFloat() * ((max - min) + 1.0f))
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+            val WIDTH = 25.0
+            val HEIGHT = 25.0
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+            val m = Mesh()
+            val b = Box(GLVector(0.2f, 0.2f, 0.2f))
+            b.material = Material()
+            b.material!!.diffuse = GLVector(1.0f, 1.0f, 1.0f)
+            b.material!!.ambient = GLVector(1.0f, 1.0f, 1.0f)
+            b.material!!.specular = GLVector(1.0f, 1.0f, 1.0f)
+            b.metadata.put(
+                    "ShaderPreference",
+                    OpenGLShaderPreference(
+                            arrayListOf("DefaultDeferredInstanced.vert", "DefaultDeferred.frag"),
+                            HashMap(),
+                            arrayListOf("DeferredShadingRenderer")))
+            scene.addChild(b)
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                try {
-                    deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
-                            mClearGLWindow!!.width,
-                            mClearGLWindow!!.height)
+            val boxes = (0..(WIDTH * HEIGHT * HEIGHT).toInt()).map {
+                val p = Node("Parent of $it")
 
-                    val cam: Camera = DetachedHeadCamera()
+                val inst = Mesh()
+                inst.name = "Box_$it"
+                inst.instanceOf = b
+                inst.material = b.material
 
-                    fun rangeRandomizer(min: Float, max: Float): Float = min + (Math.random().toFloat() * ((max - min) + 1.0f))
+                val k: Double = it % WIDTH;
+                val j: Double = (it / WIDTH) % HEIGHT;
+                val i: Double = it / (WIDTH * HEIGHT);
 
-                    val WIDTH = 25.0
-                    val HEIGHT = 25.0
+                p.position = GLVector(Math.floor(i).toFloat() * 3.0f, Math.floor(j).toFloat() * 3.0f, Math.floor(k).toFloat() * 3.0f)
+                p.needsUpdate = true
+                p.needsUpdateWorld = true
+                p.addChild(inst)
 
-                    val m = Mesh()
-                    val b = Box(GLVector(0.2f, 0.2f, 0.2f))
-                    b.material = Material()
-                    b.material!!.diffuse = GLVector(1.0f, 1.0f, 1.0f)
-                    b.material!!.ambient = GLVector(1.0f, 1.0f, 1.0f)
-                    b.material!!.specular = GLVector(1.0f, 1.0f, 1.0f)
-                    b.metadata.put(
-                            "ShaderPreference",
-                            OpenGLShaderPreference(
-                                    arrayListOf("DefaultDeferredInstanced.vert", "DefaultDeferred.frag"),
-                                    HashMap(),
-                                    arrayListOf("DeferredShadingRenderer")))
-                    scene.addChild(b)
+                m.addChild(p)
+                inst
+            }
 
-                    val boxes = (0..(WIDTH*HEIGHT*HEIGHT).toInt()).map{
-                        val p = Node("Parent of $it")
+            scene.addChild(m)
 
-                        val inst = Mesh()
-                        inst.name = "Box_$it"
-                        inst.instanceOf = b
-                        inst.material = b.material
+            var lights = (0..10).map {
+                PointLight()
+            }
 
-                        val k: Double = it % WIDTH;
-                        val j: Double = (it / WIDTH) % HEIGHT;
-                        val i: Double = it / (WIDTH * HEIGHT);
+            lights.map {
+                it.position = GLVector(rangeRandomizer(-600.0f, 600.0f),
+                        rangeRandomizer(-600.0f, 600.0f),
+                        rangeRandomizer(-600.0f, 600.0f))
+                it.emissionColor = GLVector(1.0f, 1.0f, 1.0f)
+                it.intensity = rangeRandomizer(0.01f, 1000f)
+                it.linear = 0.1f;
+                it.quadratic = 0.1f;
 
-                        p.position = GLVector(Math.floor(i).toFloat()*3.0f, Math.floor(j).toFloat()*3.0f, Math.floor(k).toFloat()*3.0f)
-                        p.needsUpdate = true
-                        p.needsUpdateWorld = true
-                        p.addChild(inst)
+                scene.addChild(it)
+            }
 
-                        m.addChild(p)
-                        inst
+            val hullbox = Box(GLVector(100.0f, 100.0f, 100.0f))
+            hullbox.position = GLVector(0.0f, 0.0f, 0.0f)
+            val hullboxM = Material()
+            hullboxM.ambient = GLVector(0.6f, 0.6f, 0.6f)
+            hullboxM.diffuse = GLVector(0.4f, 0.4f, 0.4f)
+            hullboxM.specular = GLVector(0.0f, 0.0f, 0.0f)
+            hullboxM.doubleSided = true
+            hullbox.material = hullboxM
+
+            scene.addChild(hullbox)
+
+            val mesh = Mesh()
+            val meshM = Material()
+            meshM.ambient = GLVector(0.5f, 0.5f, 0.5f)
+            meshM.diffuse = GLVector(0.5f, 0.5f, 0.5f)
+            meshM.specular = GLVector(0.1f, 0.1f, 0.1f)
+
+            cam.position = GLVector(0.0f, 0.0f, 0.0f)
+            cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+
+            cam.projection = GLMatrix().setPerspectiveProjectionMatrix(
+                    70.0f / 180.0f * Math.PI.toFloat(),
+                    pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f).invert()
+            cam.active = true
+
+            scene.addChild(cam)
+
+            var ticks: Int = 0
+
+            thread {
+                val step = 0.02f
+
+                while (true) {
+                    lights.mapIndexed {
+                        i, light ->
+                        val phi = Math.PI * 2.0f * ticks / 500.0f
+
+                        light.position = GLVector(
+                                Math.exp(i.toDouble()).toFloat() * 10 * Math.sin(phi).toFloat() + Math.exp(i.toDouble()).toFloat(),
+                                step * ticks,
+                                Math.exp(i.toDouble()).toFloat() * 10 * Math.cos(phi).toFloat() + Math.exp(i.toDouble()).toFloat())
+
                     }
 
-                    scene.addChild(m)
+                    ticks++
 
-                    var lights = (0..10).map {
-                        PointLight()
-                    }
+                    m.rotation.rotateByEuler(0.001f, 0.001f, 0.0f)
+                    m.needsUpdate = true
 
-                    lights.map {
-                        it.position = GLVector(rangeRandomizer(-600.0f, 600.0f),
-                                rangeRandomizer(-600.0f, 600.0f),
-                                rangeRandomizer(-600.0f, 600.0f))
-                        it.emissionColor = GLVector(1.0f, 1.0f, 1.0f)
-                        it.intensity = rangeRandomizer(0.01f, 1000f)
-                        it.linear = 0.1f;
-                        it.quadratic = 0.1f;
-
-                        scene.addChild(it)
-                    }
-
-                    val hullbox = Box(GLVector(100.0f, 100.0f, 100.0f))
-                    hullbox.position = GLVector(0.0f, 0.0f, 0.0f)
-                    val hullboxM = Material()
-                    hullboxM.ambient = GLVector(0.6f, 0.6f, 0.6f)
-                    hullboxM.diffuse = GLVector(0.4f, 0.4f, 0.4f)
-                    hullboxM.specular = GLVector(0.0f, 0.0f, 0.0f)
-                    hullboxM.doubleSided = true
-                    hullbox.material = hullboxM
-
-                    scene.addChild(hullbox)
-
-                    val mesh = Mesh()
-                    val meshM = Material()
-                    meshM.ambient = GLVector(0.5f, 0.5f, 0.5f)
-                    meshM.diffuse = GLVector(0.5f, 0.5f, 0.5f)
-                    meshM.specular = GLVector(0.1f, 0.1f, 0.1f)
-
-                    cam.position = GLVector(0.0f, 0.0f, 0.0f)
-                    cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
-
-                    cam.projection = GLMatrix().setPerspectiveProjectionMatrix(
-                            70.0f / 180.0f * Math.PI.toFloat(),
-                            pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f).invert()
-                    cam.active = true
-
-                    scene.addChild(cam)
-
-                    var ticks: Int = 0
-
-                    thread {
-                        val step = 0.02f
-
-                        while (true) {
-                            lights.mapIndexed {
-                                i, light ->
-                                val phi = Math.PI * 2.0f * ticks/500.0f
-
-                                light.position = GLVector(
-                                        Math.exp(i.toDouble()).toFloat()*10*Math.sin(phi).toFloat()+Math.exp(i.toDouble()).toFloat(),
-                                        step*ticks,
-                                        Math.exp(i.toDouble()).toFloat()*10*Math.cos(phi).toFloat()+Math.exp(i.toDouble()).toFloat())
-
-                            }
-
-                            ticks++
-
-                            m.rotation.rotateByEuler(0.001f, 0.001f, 0.0f)
-                            m.needsUpdate = true
-
-                            Thread.sleep(10)
-                        }
-                    }
-
-                    deferredRenderer?.initializeScene(scene)
-                } catch (e: GLException) {
-                    e.printStackTrace()
-                } catch (e: IOException) {
-                    e.printStackTrace()
+                    Thread.sleep(10)
                 }
-
             }
 
-            override fun reshape(pDrawable: GLAutoDrawable,
-                                 pX: Int,
-                                 pY: Int,
-                                 pWidth: Int,
-                                 pHeight: Int) {
-                var pHeight = pHeight
-                super.reshape(pDrawable, pX, pY, pWidth, pHeight)
-
-                if (pHeight == 0)
-                    pHeight = 1
-                val ratio = 1.0f * pWidth / pHeight
-            }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
+            deferredRenderer?.initializeScene(scene)
+        } catch (e: GLException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
         }
 
-        val lClearGLWindow = ClearGLWindow("",
-                1280,
-                720,
-                lClearGLWindowEventListener)
-
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
-
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
-
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
-        }
     }
 
-    @Test fun ScenegraphSimpleDemo() {
-
+    @Test override fun main() {
+        super.main()
     }
+
 }

--- a/src/test/kotlin/scenery/tests/examples/OpenVRExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/OpenVRExample.kt
@@ -1,13 +1,12 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import org.junit.Test
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.controls.OpenVRInput
 import scenery.rendermodules.opengl.DeferredLightingRenderer
-import scenery.repl.REPL
 import kotlin.concurrent.thread
 
 /**
@@ -15,140 +14,70 @@ import kotlin.concurrent.thread
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-class OpenVRExample {
-    private val scene: Scene = Scene()
-    private val repl: REPL = REPL()
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
+class OpenVRExample : SceneryDefaultApplication("OpenVRExample") {
     private var ovr: OpenVRInput? = null
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        ovr = OpenVRInput(useCompositor = true)
+        hub.add(SceneryElement.HMDINPUT, ovr!!)
 
-    private val hub: Hub = Hub()
+        deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, glWindow!!.width, glWindow!!.height)
+        hub.add(SceneryElement.RENDERER, deferredRenderer!!)
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+        var box = Box(GLVector(1.0f, 1.0f, 1.0f))
+        var boxmaterial = Material()
+        boxmaterial.ambient = GLVector(1.0f, 0.0f, 0.0f)
+        boxmaterial.diffuse = GLVector(0.0f, 1.0f, 0.0f)
+        boxmaterial.specular = GLVector(1.0f, 1.0f, 1.0f)
+        boxmaterial.textures.put("diffuse", this.javaClass.getResource("textures/helix.png").file)
+        box.material = boxmaterial
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+        box.position = GLVector(0.0f, 0.0f, 0.0f)
+        scene.addChild(box)
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                ovr = OpenVRInput(useCompositor = true)
-                hub.add(SceneryElement.HMDINPUT, ovr!!)
-
-                deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, mClearGLWindow!!.width, mClearGLWindow!!.height)
-                hub.add(SceneryElement.RENDERER, deferredRenderer!!)
-
-                var box = Box(GLVector(1.0f, 1.0f, 1.0f))
-                var boxmaterial = Material()
-                boxmaterial.ambient = GLVector(1.0f, 0.0f, 0.0f)
-                boxmaterial.diffuse = GLVector(0.0f, 1.0f, 0.0f)
-                boxmaterial.specular = GLVector(1.0f, 1.0f, 1.0f)
-                boxmaterial.textures.put("diffuse", this.javaClass.getResource("textures/helix.png").file)
-                box.material = boxmaterial
-
-                box.position = GLVector(0.0f, 0.0f, 0.0f)
-                scene.addChild(box)
-
-                var lights = (0..2).map {
-                    PointLight()
-                }
-
-                lights.mapIndexed { i, light ->
-                    light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
-                    light.emissionColor = GLVector(1.0f, 0.0f, 1.0f)
-                    light.intensity = 0.2f*(i+1);
-                    scene.addChild(light)
-                }
-
-                val cam: Camera = DetachedHeadCamera()
-                cam.position = GLVector(0.0f, 0.0f, -5.0f)
-                cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
-                cam.projection = GLMatrix()
-                        .setPerspectiveProjectionMatrix(
-                                70.0f / 180.0f * Math.PI.toFloat(),
-                                1024f / 1024f, 0.1f, 1000.0f)
-                cam.active = true
-
-                scene.addChild(cam)
-
-                thread {
-                    while (true) {
-                        box.rotation.rotateByAngleY(0.01f)
-                        box.needsUpdate = true
-
-                        Thread.sleep(20)
-                    }
-                }
-
-                deferredRenderer?.initializeScene(scene)
-
-                repl.addAccessibleObject(scene)
-                repl.addAccessibleObject(deferredRenderer!!)
-                repl.start()
-
-                repl.showConsoleWindow()
-            }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-                ovr?.updatePose()
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-
-                if(deferredRenderer?.settings?.get<Boolean>("wantsFullscreen") == true && deferredRenderer?.settings?.get<Boolean>("isFullscreen") == false) {
-                    mClearGLWindow!!.setFullscreen(true)
-                    deferredRenderer?.settings?.set("wantsFullscreen", true)
-                    deferredRenderer?.settings?.set("isFullscreen", true)
-                }
-
-                if(deferredRenderer?.settings?.get<Boolean>("wantsFullscreen") == false && deferredRenderer?.settings?.get<Boolean>("isFullscreen") == true) {
-                    mClearGLWindow!!.setFullscreen(false)
-                    deferredRenderer?.settings?.set("wantsFullscreen", false)
-                    deferredRenderer?.settings?.set("isFullscreen", false)
-                }
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
-            override fun reshape(pDrawable: GLAutoDrawable,
-                                 pX: Int,
-                                 pY: Int,
-                                 pWidth: Int,
-                                 pHeight: Int) {
-                var pHeight = pHeight
-
-                if (pHeight == 0)
-                    pHeight = 1
-
-                super.reshape(pDrawable, pX, pY, pWidth, pHeight)
-                deferredRenderer?.reshape(pWidth, pHeight)
-            }
-
+        var lights = (0..2).map {
+            PointLight()
         }
 
-        val lClearGLWindow = ClearGLWindow("",
-                3024,
-                1680,
-                lClearGLWindowEventListener)
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
-
-        System.out.println(System.getProperty("java.class.path"))
-
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
-
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
+        lights.mapIndexed { i, light ->
+            light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
+            light.emissionColor = GLVector(1.0f, 0.0f, 1.0f)
+            light.intensity = 0.2f * (i + 1);
+            scene.addChild(light)
         }
+
+        val cam: Camera = DetachedHeadCamera()
+        cam.position = GLVector(0.0f, 0.0f, -5.0f)
+        cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+        cam.projection = GLMatrix()
+                .setPerspectiveProjectionMatrix(
+                        70.0f / 180.0f * Math.PI.toFloat(),
+                        1024f / 1024f, 0.1f, 1000.0f)
+        cam.active = true
+
+        scene.addChild(cam)
+
+        thread {
+            while (true) {
+                box.rotation.rotateByAngleY(0.01f)
+                box.needsUpdate = true
+
+                Thread.sleep(20)
+            }
+        }
+
+        deferredRenderer?.initializeScene(scene)
+
+        repl.addAccessibleObject(scene)
+        repl.addAccessibleObject(deferredRenderer!!)
+        repl.start()
+
+        repl.showConsoleWindow()
     }
+
+    @Test override fun main() {
+        super.main()
+    }
+
+
 }

--- a/src/test/kotlin/scenery/tests/examples/TexturedCubeExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/TexturedCubeExample.kt
@@ -23,7 +23,7 @@ class TexturedCubeExample : SceneryDefaultApplication("TexturedCubeExample") {
             ambient = GLVector(1.0f, 0.0f, 0.0f)
             diffuse = GLVector(0.0f, 1.0f, 0.0f)
             specular = GLVector(1.0f, 1.0f, 1.0f)
-            textures.put("diffuse", this.javaClass.getResource("textures/helix.png").file)
+            textures.put("diffuse", TexturedCubeExample::class.java.getResource("textures/helix.png").file)
         }
 
         var box = Box(GLVector(1.0f, 1.0f, 1.0f))

--- a/src/test/kotlin/scenery/tests/examples/VertexUpdateExample.kt
+++ b/src/test/kotlin/scenery/tests/examples/VertexUpdateExample.kt
@@ -1,10 +1,10 @@
 package scenery.tests.examples
 
-import cleargl.*
+import cleargl.GLMatrix
+import cleargl.GLVector
 import com.jogamp.opengl.GLAutoDrawable
 import org.junit.Test
 import scenery.*
-import scenery.controls.ClearGLInputHandler
 import scenery.rendermodules.opengl.DeferredLightingRenderer
 import java.util.*
 import kotlin.concurrent.thread
@@ -15,151 +15,118 @@ import kotlin.concurrent.thread
  * @author Ulrik Günther <hello@ulrik.is>
  */
 
-class VertexUpdateExample {
-    private val scene: Scene = Scene()
-    private var frameNum = 0
-    private var deferredRenderer: DeferredLightingRenderer? = null
-    private var hub: Hub = Hub()
+class VertexUpdateExample : SceneryDefaultApplication("VertexUpdateExample") {
 
-    @Test fun demo() {
-        val lClearGLWindowEventListener = object : ClearGLDefaultEventListener() {
+    override fun init(pDrawable: GLAutoDrawable) {
+        super.init(pDrawable)
+        deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4,
+                glWindow!!.width, glWindow!!.height)
+        hub.add(SceneryElement.RENDERER, deferredRenderer!!)
 
-            private var mClearGLWindow: ClearGLDisplayable? = null
+        var sphere = Sphere(2.0f, 50)
 
-            override fun init(pDrawable: GLAutoDrawable) {
-                super.init(pDrawable)
-                deferredRenderer = DeferredLightingRenderer(pDrawable.gl.gL4, mClearGLWindow!!.width, mClearGLWindow!!.height)
-                hub.add(SceneryElement.RENDERER, deferredRenderer!!)
+        var material = Material()
+        material.ambient = GLVector(1.0f, 1.0f, 1.0f)
+        material.diffuse = GLVector(1.0f, 1.0f, 1.0f)
+        material.specular = GLVector(1.0f, 1.0f, 1.0f)
+        material.doubleSided = true
 
-                var sphere = Sphere(2.0f, 50)
+        sphere.position = GLVector(0.0f, 0.0f, 0.0f)
+        sphere.material = material
 
-                var material = Material()
-                material.ambient = GLVector(1.0f, 1.0f, 1.0f)
-                material.diffuse = GLVector(1.0f, 1.0f, 1.0f)
-                material.specular = GLVector(1.0f, 1.0f, 1.0f)
-                material.doubleSided = true
+        scene.addChild(sphere)
 
-                sphere.position = GLVector(0.0f, 0.0f, 0.0f)
-                sphere.material = material
+        var lights = (0..2).map {
+            PointLight()
+        }
 
-                scene.addChild(sphere)
+        lights.mapIndexed { i, light ->
+            light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
+            light.emissionColor = GLVector(1.0f, 1.0f, 1.0f)
+            light.intensity = 100f * (i + 1);
+            scene.addChild(light)
+        }
 
-                var lights = (0..2).map {
-                    PointLight()
-                }
+        val cam: Camera = DetachedHeadCamera()
+        cam.position = GLVector(0.0f, 0.0f, -5.0f)
+        cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
+        cam.projection = GLMatrix()
+                .setPerspectiveProjectionMatrix(
+                        70.0f / 180.0f * Math.PI.toFloat(),
+                        pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f)
+                .invert()
+        cam.active = true
 
-                lights.mapIndexed { i, light ->
-                    light.position = GLVector(2.0f * i, 2.0f * i, 2.0f * i)
-                    light.emissionColor = GLVector(1.0f, 1.0f, 1.0f)
-                    light.intensity = 100f * (i + 1);
-                    scene.addChild(light)
-                }
+        scene.addChild(cam)
 
-                val cam: Camera = DetachedHeadCamera()
-                cam.position = GLVector(0.0f, 0.0f, -5.0f)
-                cam.view = GLMatrix().setCamera(cam.position, cam.position + cam.forward, cam.up)
-                cam.projection = GLMatrix()
-                        .setPerspectiveProjectionMatrix(
-                                70.0f / 180.0f * Math.PI.toFloat(),
-                                pDrawable.surfaceWidth.toFloat() / pDrawable.surfaceHeight.toFloat(), 0.1f, 1000.0f)
-                        .invert()
-                cam.active = true
+        var ticks = 0
+        thread {
+            while (true) {
+                sphere.rotation.rotateByAngleY(0.01f)
+                sphere.needsUpdate = true
+                ticks++
 
-                scene.addChild(cam)
+                val vbuffer = ArrayList<Float>()
+                val nbuffer = ArrayList<Float>()
 
-                var ticks = 0
-                thread {
-                    while (true) {
-                        sphere.rotation.rotateByAngleY(0.01f)
-                        sphere.needsUpdate = true
-                        ticks++
+                val segments = 50
+                val radius = 2.0f
+                for (i in 0..segments) {
+                    val lat0: Float = Math.PI.toFloat() * (-0.5f + (i.toFloat() - 1.0f) / segments.toFloat());
+                    val lat1: Float = Math.PI.toFloat() * (-0.5f + i.toFloat() / segments.toFloat());
 
-                        val vbuffer = ArrayList<Float>()
-                        val nbuffer = ArrayList<Float>()
+                    val z0 = Math.sin(lat0.toDouble()).toFloat()
+                    val z1 = Math.sin(lat1.toDouble()).toFloat()
 
-                        val segments = 50
-                        val radius = 2.0f
-                        for(i in 0..segments) {
-                            val lat0: Float = Math.PI.toFloat() * (-0.5f + (i.toFloat() - 1.0f) / segments.toFloat());
-                            val lat1: Float = Math.PI.toFloat() * (-0.5f + i.toFloat() / segments.toFloat());
+                    val zr0 = Math.cos(lat0.toDouble()).toFloat()
+                    val zr1 = Math.cos(lat1.toDouble()).toFloat()
 
-                            val z0 = Math.sin(lat0.toDouble()).toFloat()
-                            val z1 = Math.sin(lat1.toDouble()).toFloat()
+                    for (j: Int in 1..segments) {
+                        val lng = 2 * Math.PI.toFloat() * (j - 1) / segments
+                        val x = Math.cos(lng.toDouble()).toFloat()
+                        val y = Math.sin(lng.toDouble()).toFloat()
+                        var r = radius
 
-                            val zr0 = Math.cos(lat0.toDouble()).toFloat()
-                            val zr1 = Math.cos(lat1.toDouble()).toFloat()
-
-                            for (j: Int in 1..segments) {
-                                val lng = 2 * Math.PI.toFloat() * (j - 1) / segments
-                                val x = Math.cos(lng.toDouble()).toFloat()
-                                val y = Math.sin(lng.toDouble()).toFloat()
-                                var r = radius
-
-                                if(j % 10 == 0) {
-                                    r = radius + Math.sin(ticks/100.0).toFloat()
-                                }
-                                vbuffer.add(x * zr0 * r)
-                                vbuffer.add(y * zr0 * r)
-                                vbuffer.add(z0 * r)
-
-                                vbuffer.add(x * zr1 * r)
-                                vbuffer.add(y * zr1 * r)
-                                vbuffer.add(z1 * r)
-
-                                nbuffer.add(x)
-                                nbuffer.add(y)
-                                nbuffer.add(z0)
-
-                                nbuffer.add(x)
-                                nbuffer.add(y)
-                                nbuffer.add(z1)
-                            }
+                        if (j % 10 == 0) {
+                            r = radius + Math.sin(ticks / 100.0).toFloat()
                         }
+                        vbuffer.add(x * zr0 * r)
+                        vbuffer.add(y * zr0 * r)
+                        vbuffer.add(z0 * r)
 
-                        sphere.vertices = vbuffer.toFloatArray()
-                        sphere.normals = nbuffer.toFloatArray()
-                        sphere.recalculateNormals()
+                        vbuffer.add(x * zr1 * r)
+                        vbuffer.add(y * zr1 * r)
+                        vbuffer.add(z1 * r)
 
-                        sphere.dirty = true
+                        nbuffer.add(x)
+                        nbuffer.add(y)
+                        nbuffer.add(z0)
 
-                        Thread.sleep(20)
+                        nbuffer.add(x)
+                        nbuffer.add(y)
+                        nbuffer.add(z1)
                     }
                 }
-                deferredRenderer?.initializeScene(scene)
+
+                sphere.vertices = vbuffer.toFloatArray()
+                sphere.normals = nbuffer.toFloatArray()
+                sphere.recalculateNormals()
+
+                sphere.dirty = true
+
+                Thread.sleep(20)
             }
-
-            override fun display(pDrawable: GLAutoDrawable) {
-                super.display(pDrawable)
-
-                frameNum++
-                deferredRenderer?.render(scene)
-                clearGLWindow.windowTitle = "scenery: %s - %.1f fps".format(this.javaClass.enclosingClass.simpleName.substringAfterLast("."), pDrawable.animator?.lastFPS)
-            }
-
-            override fun setClearGLWindow(pClearGLWindow: ClearGLWindow) {
-                mClearGLWindow = pClearGLWindow
-            }
-
-            override fun getClearGLWindow(): ClearGLDisplayable {
-                return mClearGLWindow!!
-            }
-
         }
+        deferredRenderer?.initializeScene(scene)
 
-        val lClearGLWindow = ClearGLWindow("",
-                1024,
-                1024,
-                lClearGLWindowEventListener)
-        lClearGLWindow.isVisible = true
-        lClearGLWindow.setFPS(60)
+        repl.addAccessibleObject(scene)
+        repl.addAccessibleObject(deferredRenderer!!)
+        repl.start()
 
-        val inputHandler = ClearGLInputHandler(scene, deferredRenderer as Any, lClearGLWindow)
-        inputHandler.useDefaultBindings(System.getProperty("user.home") + "/.sceneryExamples.bindings")
+        repl.showConsoleWindow()
+    }
 
-        lClearGLWindow.start()
-
-        while (lClearGLWindow.isVisible) {
-            Thread.sleep(10)
-        }
+    @Test override fun main() {
+        super.main()
     }
 }


### PR DESCRIPTION
This PR moves scenery's examples over to use the new SceneryDefaultApplication class, reducing the boilerplate code needed from setup, so the actual example code is highlighted more.