### PR TITLE
Moving to ClearGL 2.0.0 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 
 install:
   - cd ..
-  - git clone -b scenegraph git://github.com/ClearVolume/ClearGL.git ClearGL
+  - git clone git://github.com/ClearVolume/ClearGL.git ClearGL
   - echo "include 'ClearGL'" >> settings.gradle
   - echo "include 'scenery'" >> settings.gradle
   - cd scenery

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ scenery is a scenegraphing and rendering library. It allows you to quickly creat
 
 - Create a base directory named e.g. `my_scenery_base`. Into this directory, clone the Git repository of scenery.
 
-- Into the same directory, clone the `scenegraph` branch of ClearGL’s Git repository: 
+- Into the same directory, clone the 2.0 version of ClearGL’s Git repository: 
 ```shell
-git clone -b scenegraph https://github.com/ClearVolume/ClearGL.git
+git clone https://github.com/ClearVolume/ClearGL.git
 ```
 
 - In the `my_scenery_base` directory, create a file named `settings.gradle`, with this content:
@@ -49,7 +49,7 @@ Add these dependencies to your project's `pom.xml`:
   <dependency>
     <groupId>net.clearvolume</groupId>
     <artifactId>cleargl</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </dependency>
 </dependencies>
 ```
@@ -61,5 +61,5 @@ Make sure you have followed the instructions in _Building_, such that both the s
 Add these dependencies to your project's `build.gradle`:
 ```groovy
 compile group: 'net.clearvolume', name: 'scenery', version: '1.0-SNAPSHOT'
-compile group: 'net.clearvolume', name: 'cleargl', version: '1.0-SNAPSHOT'
+compile group: 'net.clearvolume', name: 'cleargl', version: '2.0.0-SNAPSHOT'
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies
 	}
 	else {
 		println 'Using clearX from Maven repository'/**/
-		compile group: "net.clearvolume", name: "cleargl", version: "(,1.1.0]", changing: true, transitive: true
+		compile group: "net.clearvolume", name: "cleargl", version: "2.0.0-SNAPSHOT", changing: true, transitive: true
 	}
 
 

--- a/src/main/kotlin/scenery/GenericTexture.kt
+++ b/src/main/kotlin/scenery/GenericTexture.kt
@@ -1,7 +1,7 @@
 package scenery
 
+import cleargl.GLTypeEnum
 import cleargl.GLVector
-import coremem.types.NativeTypeEnum
 import java.nio.ByteBuffer
 
 /**
@@ -17,7 +17,7 @@ data class GenericTexture(
     /** The texture's number of channels */
     var channels: Int = 4,
     /** [NativeTypeEnum] declaring the data type stored in [contents] */
-    var type: NativeTypeEnum = NativeTypeEnum.Byte,
+    var type: GLTypeEnum = GLTypeEnum.Byte,
     /** Byte contents of the texture */
     var contents: ByteBuffer,
     /** Shall the texture be repeated on the U/S coordinate? */

--- a/src/main/kotlin/scenery/rendermodules/opengl/DeferredLightingRenderer.kt
+++ b/src/main/kotlin/scenery/rendermodules/opengl/DeferredLightingRenderer.kt
@@ -4,7 +4,6 @@ import cleargl.*
 import com.jogamp.common.nio.Buffers
 import com.jogamp.opengl.GL
 import com.jogamp.opengl.GL4
-import coremem.types.NativeTypeEnum
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import scenery.*
@@ -458,7 +457,7 @@ open class DeferredLightingRenderer : Renderer, Hubable {
 
         val s = getOpenGLObjectStateFromNode(board)
         val texture = textures.getOrPut("sdf-${board.fontFamily}", {
-            val t = GLTexture(gl, NativeTypeEnum.Float, 1,
+            val t = GLTexture(gl, GLTypeEnum.Float, 1,
                 atlas.atlasWidth,
                 atlas.atlasHeight,
                 1,


### PR DESCRIPTION
* ClearGL is at 2.0.0-SNAPSHOT now, after merging the scenegraph branch
* This updates README and build files
* adjustments to GenericTexture and DeferredLightingRenderer such that the texture data
  types do not depend on CoreMem