### PR TITLE
Use the 3.1.1 release of LWJGL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <kotlin.version>1.0.5-2</kotlin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <dokka.version>0.9.10</dokka.version>
-        <lwjgl.version>3.1.1-SNAPSHOT</lwjgl.version>
+        <lwjgl.version>3.1.1</lwjgl.version>
         <license.licenseName>lgpl_v3</license.licenseName>
 
         <enforcer.skip>true</enforcer.skip>


### PR DESCRIPTION
The `3.1.1-SNAPSHOT` builds are [gone now](http://maven.imagej.net/service/local/artifact/maven/redirect?r=sonatype-snapshots&g=org.lwjgl&a=lwjgl&v=3.1.1-SNAPSHOT&e=pom), due to the snapshot retention policy of the OSS Sonatype Snapshots repository. Using `3.1.1` instead is stable and fixes the build.